### PR TITLE
Update Sponsor Year to 2025

### DIFF
--- a/src/views/2025/SponsorsView.vue
+++ b/src/views/2025/SponsorsView.vue
@@ -255,7 +255,7 @@ import SponsorItem from "../../components/2025/home/SponsorItem.vue";
         </p>
         <h3>Contact Info</h3>
         <p>
-          If you would like to sponsor CPOSC 2024, please send an email to
+          If you would like to sponsor CPOSC 2025, please send an email to
           sponsor@localareanetworks.org. One of the organizers will respond
           promptly.
         </p>


### PR DESCRIPTION
I wasn't sure if the year should be updated or removed, but it still said 2024, so I figured it should be updated. If you want the year removed to make the site more reusable from year to year, let me know and I can remove it.